### PR TITLE
支持配置MongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,8 @@ pip install -r requirements.txt
         "user": "root",
         "password": "123456",
         "charset": "utf8mb4"
-    }
+    },
+    "mongodb_URI": "mongodb://[username:password@]host[:port][/[defaultauthdb][?options]]"
 }
 ```
 
@@ -470,6 +471,11 @@ cookie为可选参数，即可填可不填，具体区别见[添加cookie与不�
 **设置mysql_config（可选）**
 
 mysql_config控制mysql参数配置。如果你不需要将结果信息写入mysql，这个参数可以忽略，即删除或保留都无所谓；如果你需要写入mysql且config.json文件中mysql_config的配置与你的mysql配置不一样，请将该值改成你自己mysql中的参数配置。
+
+**设置mongodb_URI（可选）**
+
+mongodb_URI是mongodb的连接字符串。如果你不需要将结果信息写入mongodb，这个参数可以忽略，即删除或保留都无所谓；如果你需要写入mongodb，则需要配置为[完整的mongodb URI](https://www.mongodb.com/docs/manual/reference/connection-string/)。
+
 **设置start_page（可选）**
 
 start_page为爬取微博的初始页数，默认参数为1，即从所爬取用户的当前第一页微博内容开始爬取。

--- a/config.json
+++ b/config.json
@@ -25,5 +25,6 @@
         "user": "root",
         "password": "123456",
         "charset": "utf8mb4"
-    }
+    },
+    "mongodb_URI": "mongodb://[username:password@]host[:port][/[defaultauthdb][?options]]"
 }

--- a/weibo.py
+++ b/weibo.py
@@ -83,6 +83,7 @@ class Weibo(object):
         user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.111 Safari/537.36"
         self.headers = {"User_Agent": user_agent, "Cookie": cookie}
         self.mysql_config = config.get("mysql_config")  # MySQL数据库连接配置，可以不填
+        self.mongodb_URI = config.get("mongodb_URI")  # MongoDB数据库连接字符串，可以不填
         user_id_list = config["user_id_list"]
         query_list = config.get("query_list") or []
         if isinstance(query_list, str):
@@ -1366,7 +1367,7 @@ class Weibo(object):
         try:
             from pymongo import MongoClient
 
-            client = MongoClient()
+            client = MongoClient(self.mongodb_URI)
             db = client["weibo"]
             collection = db[collection]
             if len(self.write_mode) > 1:


### PR DESCRIPTION
当前MongoDB只能是本机上安装的，并且是默认配置，使用起来有些不便。
修改为可以传入`MongoDB数据库连接字符串`，就可以配置为**远程数据库**了。