### PR TITLE
Fix 微博的文本内容为空时，selector为None，会导致后续解析出错

### DIFF
--- a/weibo.py
+++ b/weibo.py
@@ -724,7 +724,7 @@ class Weibo(object):
         weibo["id"] = int(weibo_info["id"])
         weibo["bid"] = weibo_info["bid"]
         text_body = weibo_info["text"]
-        selector = etree.HTML(text_body)
+        selector = etree.HTML(f"{text_body}<hr>" if text_body.isspace() else text_body)
         if self.remove_html_tag:
             weibo["text"] = selector.xpath("string(.)")
         else:


### PR DESCRIPTION
当微博的文本内容为空时（json里`"mblog"."text": " "`），`etree.HTML(text_body)`的返回值为`None`，这会导致后续解析出错。

**报错信息**：
```
2023-01-26 12:49:59,376 - ERROR - weibo.py[:842] - 'NoneType' object has no attribute 'xpath'
Traceback (most recent call last):
  File "D:\tmp\code\weibo-crawler\weibo.py", line 836, in get_one_weibo
    weibo = self.parse_weibo(weibo_info)
  File "D:\tmp\code\weibo-crawler\weibo.py", line 732, in parse_weibo
    weibo["article_url"] = self.get_article_url(selector)
  File "D:\tmp\code\weibo-crawler\weibo.py", line 633, in get_article_url
    text = selector.xpath("string(.)")
AttributeError: 'NoneType' object has no attribute 'xpath'
```

**例如**：生日当天自动发的生日微博，其内容为空（json里`"mblog"."text": " "`）：
![image](https://user-images.githubusercontent.com/17940898/214769655-37e46b99-8c2b-4c05-b0d9-306bca3c7472.png)

返回的**原始json**里`"mblog"."text": " "`，如下图：
![image](https://user-images.githubusercontent.com/17940898/214769859-0fdf8ec9-1ae9-4990-8660-d19e5f27c9e8.png)

**修复方式**：在`空字符串`的末尾追加`<hr>`，此时会变成有效的html字符串，会被正确解析并返回html对象，后续即可正常使用。而`<hr>`是自结束的`水平线`，不会影响正常的数据解析。
