### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,16 +836,16 @@ docker run -it -d \
 
 ```yaml
 version: '3'
-  services:
-    weibo-crawler:
-      build:
-        context: .
-        dockerfile: Dockerfile
-      volumes:
-        - path/to/config.json:/app/config.json
-        - path/to/weibo:/app/weibo
-      environment:
-        - schedule_interval=1 # 可选：循环间隔（分钟）
+services:
+  weibo-crawler:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - path/to/config.json:/app/config.json
+      - path/to/weibo:/app/weibo
+    environment:
+      - schedule_interval=1 # 可选：循环间隔（分钟）
 ```
 
 ## 如何获取user_id


### PR DESCRIPTION
`docker-compose.yml`文件内容的第一个字段 `version:` 和第二个字段 `services:` 的缩进层级应该是相同的，都应该在文件的最左侧，而不是 `services:` 下的字段比 `version:` 缩进一个空格。