### PR TITLE
Update lxml version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lxml==4.9.3
+lxml==5.3.0
 pymongo==4.6.3
 PyMySQL==1.1.1
 Requests==2.32.0


### PR DESCRIPTION
4.9.3 在windows11会安装失败，替换成最新的。