### PR TITLE
fix: 修复MySQL/SQLite存储时帖子信息无法保存的问题，并添加live_photo_url字段

### DIFF
--- a/weibo.py
+++ b/weibo.py
@@ -1793,6 +1793,7 @@ class Weibo(object):
                 at_users varchar(1000),
                 pics varchar(3000),
                 video_url varchar(1000),
+                live_photo_url varchar(1000),
                 location varchar(100),
                 created_at DATETIME,
                 source varchar(30),
@@ -1968,6 +1969,7 @@ class Weibo(object):
         sqlite_weibo["topics"] = weibo["topics"]
         sqlite_weibo["pics"] = weibo["pics"]
         sqlite_weibo["video_url"] = weibo["video_url"]
+        sqlite_weibo["live_photo_url"] = weibo["live_photo_url"]
         sqlite_weibo["location"] = weibo["location"]
         sqlite_weibo["created_at"] = weibo["full_created_at"]
         sqlite_weibo["source"] = weibo["source"]
@@ -2071,6 +2073,7 @@ class Weibo(object):
                     ,at_users varchar(1000)
                     ,pics varchar(3000)
                     ,video_url varchar(1000)
+                    ,live_photo_url varchar(1000)
                     ,location varchar(100)
                     ,created_at DATETIME
                     ,source varchar(30)


### PR DESCRIPTION
# PR: 修复MySQL/SQLite存储时帖子信息无法保存的问题，并添加live_photo_url字段

## 修复内容
1. 在MySQL建表语句中新增`live_photo_url`字段（VARCHAR类型）
2. 在SQLite保存方法中添加`live_photo_url`字段的处理逻辑
3. 修复MySQL和SQLite存储引擎下帖子信息无法保存的问题

## 问题背景
此前在使用MySQL或SQLite存储帖子数据时，由于缺少`live_photo_url`字段的支持，导致保存操作失败。本次修改确保了两种数据库都能正常存储包含Live Photo URL的帖子信息。

## 测试验证
- 已验证MySQL和SQLite环境下帖子保存功能正常
- 新增字段在数据库中正确创建并可正常读写