### PR TITLE
fix: 使用config.json中的output_directory配置替换硬编码的'weibo'路径

### DIFF
--- a/weibo.py
+++ b/weibo.py
@@ -122,6 +122,9 @@ class Weibo(object):
         self.change_file_time = config.get(
             "change_file_time", 0
         )  # 是否修改文件时间，取值范围为0、1, 0代表不开启, 1代表开启
+        self.output_directory = config.get(
+            "output_directory", "weibo"
+        )  # 输出目录配置，默认为"weibo"
         
         # Cookie支持：优先使用环境变量WEIBO_COOKIE，其次使用config.json中的配置
         cookie_string = os.environ.get("WEIBO_COOKIE") or config.get("cookie")
@@ -653,7 +656,7 @@ class Weibo(object):
     
     def user_to_csv(self):
         """将爬取到的用户信息写入csv文件"""
-        file_dir = os.path.split(os.path.realpath(__file__))[0] + os.sep + "weibo"
+        file_dir = os.path.split(os.path.realpath(__file__))[0] + os.sep + self.output_directory
         if not os.path.isdir(file_dir):
             os.makedirs(file_dir)
         file_path = file_dir + os.sep + "users.csv"
@@ -1975,7 +1978,7 @@ class Weibo(object):
             file_dir = (
                 os.path.split(os.path.realpath(__file__))[0]
                 + os.sep
-                + "weibo"
+                + self.output_directory
                 + os.sep
                 + dir_name
             )


### PR DESCRIPTION
## 修复内容

解决 issue #625: config.json中设置了output_directory，但代码仍使用硬编码的'weibo'路径

### 修改内容:
1. 在Weibo类的__init__方法中添加`self.output_directory`属性，读取config.json中的output_directory配置
2. 将`user_to_csv`方法中的硬编码`'weibo'`替换为`self.output_directory`
3. 将`get_filepath`方法中的硬编码`'weibo'`替换为`self.output_directory`

### 测试结果:
代码已通过测试，正确读取了config.json中的`output_directory: weibo_data`配置

### 关联Issue:
Closes #625