### PR TITLE
feat:<>使用cookie文件替代config中的cookie字符串，并且在抓取结束后自动更新cookie文件（如有）

### DIFF
--- a/weibo.py
+++ b/weibo.py
@@ -129,8 +129,20 @@ class Weibo(object):
         )  # 输出目录配置，默认为"weibo"
         
         # Cookie支持：优先使用环境变量WEIBO_COOKIE，其次使用config.json中的配置
-        cookie_string = os.environ.get("WEIBO_COOKIE") or config.get("cookie")
-        if os.environ.get("WEIBO_COOKIE"):
+        cookie_config = config.get("cookie")
+        cookie_string = os.environ.get("WEIBO_COOKIE") or cookie_config
+        
+        self.cookie_file_path = None
+        if isinstance(cookie_config, str) and cookie_config.endswith('.txt'):
+            self.cookie_file_path = cookie_config
+            if os.path.isfile(self.cookie_file_path):
+                with open(self.cookie_file_path, 'r', encoding='utf-8') as f:
+                    cookie_string = f.read().strip()
+                logger.info(f"从Cookie文件 {self.cookie_file_path} 读取Cookie")
+            else:
+                logger.warning(f"Cookie文件 {self.cookie_file_path} 不存在，将使用默认空Cookie")
+                cookie_string = ""
+        elif os.environ.get("WEIBO_COOKIE"):
             logger.info("使用环境变量WEIBO_COOKIE中的Cookie")
         
         core_cookies = {}   # 核心包
@@ -3456,6 +3468,26 @@ class Weibo(object):
         self.got_count = 0
         self.weibo_id_list = []
 
+    def save_cookies_to_file(self):
+        """将 Session 中最新的 Cookie 写回文件"""
+        if not self.cookie_file_path:
+            return
+        
+        try:
+            # 将 requests.cookies.RequestsCookieJar 转换为字符串格式 "key=value; key2=value2"
+            cookie_list = []
+            for cookie in self.session.cookies:
+                cookie_list.append(f"{cookie.name}={cookie.value}")
+            
+            cookie_string = "; ".join(cookie_list)
+            
+            with open(self.cookie_file_path, 'w', encoding='utf-8') as f:
+                f.write(cookie_string)
+            
+            logger.info(f"最新的 Cookie 已写回文件: {self.cookie_file_path}")
+        except Exception as e:
+            logger.error(f"保存 Cookie 到文件失败: {e}")
+
     def start(self):
         """运行爬虫"""
         try:
@@ -3478,6 +3510,8 @@ class Weibo(object):
                     self.update_user_config_file(self.user_config_file_path)
         except Exception as e:
             logger.exception(e)
+        finally:
+            self.save_cookies_to_file()
 
 
 def handle_config_renaming(config, oldName, newName):


### PR DESCRIPTION
不知道有没有其他的小伙伴遇到过类似的问题？
- 通过浏览器提取cookie之后填入config.json配置文件
- 每天让定时任务运行一段时间（可能每隔一个多月或者几个月吧）
- 出现抓取失败

此时必须更新`config.json`中的cookie，但是打开浏览器`m.weibo.cn`并没有要求重新登录，只需要重新复制cookie后再贴进去就好了。

python的request库是会在跟服务器通信的过程当中自动更新cookie的，也就是有些请求服务端会下发`Set-Cookie`的响应头，python的requests库会自动对这些响应进行处理，既然如此，那是不是可以在每次抓取完成之后把内存当中由requests库维护的最新的cookie的值写回到本地的配置文件中？**不确定**是不是可以免除手动更新cookie的烦恼。

因为每次去让python脚本修改`config.json`文件并不是很合适。所以改成了在配置文件当中可以指定一个文本文件来存放Cookie。